### PR TITLE
Add better output messages, and exit on failure.

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -18659,6 +18659,7 @@ class SyncConfluence {
         (err, data) => {
           if (err) {
             console.error(err);
+            process.exit(1);
           } else {
             if (data.results[0]) {
               resolve(data.results[0].id);
@@ -18675,6 +18676,7 @@ class SyncConfluence {
     return this.confluenceApi.getContentById(pageId, (err, data) => {
       if (err) {
         console.error(err);
+        process.exit(1);
       } else {
         cb(data.version.number);
       }
@@ -18691,6 +18693,7 @@ class SyncConfluence {
         (err, data) => {
           if (err) {
             console.error(err);
+            process.exit(1);
           } else {
             resolve(data.id);
           }
@@ -18710,7 +18713,10 @@ class SyncConfluence {
         (err, data) => {
           if (err) {
             console.error(err);
-          }
+            process.exit(1);
+          } else {
+            console.log("Uploaded content successfuly to page %s", data._links.base + data._links.webui);
+          }          
         },
         false,
         "editor2"
@@ -18726,6 +18732,7 @@ class SyncConfluence {
           (err, data) => {
             if (err) {
               console.error(err);
+              process.exit(1);
             } else {
               if (data.results[0]) {
                 resolve(data.results);
@@ -18748,6 +18755,7 @@ class SyncConfluence {
           (err, data) => {
             if (err) {
               console.error(err);
+              process.exit(1);
             } else {
               if (data) {
                 resolve(data);
@@ -18769,6 +18777,7 @@ class SyncConfluence {
           (err, data) => {
             if (err) {
               console.error(err);
+              process.exit(1);s
             } else {
               if (data.results[0]) {
                 resolve(data.results[0]);
@@ -21875,6 +21884,10 @@ async function handleAttachments(contentPageId, data) {
 }
 
 async function main() {
+  const files = filesStructure(root);
+  if (!files.length) {
+    console.log("No markdown files found in %s", root);
+  }
   for (const f of filesStructure(root)) {
     let path = f.join("/");
     let currentParentPageId = rootParentPageId;

--- a/dist/index.js
+++ b/dist/index.js
@@ -21888,7 +21888,7 @@ async function main() {
   if (!files.length) {
     console.log("No markdown files found in %s", root);
   }
-  for (const f of filesStructure(root)) {
+  for (const f of files) {
     let path = f.join("/");
     let currentParentPageId = rootParentPageId;
     for (const subPath of f) {

--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ async function main() {
   if (!files.length) {
     console.log("No markdown files found in %s", root);
   }
-  for (const f of filesStructure(root)) {
+  for (const f of files) {
     let path = f.join("/");
     let currentParentPageId = rootParentPageId;
     for (const subPath of f) {

--- a/index.js
+++ b/index.js
@@ -71,6 +71,10 @@ async function handleAttachments(contentPageId, data) {
 }
 
 async function main() {
+  const files = filesStructure(root);
+  if (!files.length) {
+    console.log("No markdown files found in %s", root);
+  }
   for (const f of filesStructure(root)) {
     let path = f.join("/");
     let currentParentPageId = rootParentPageId;

--- a/utils/confluence.js
+++ b/utils/confluence.js
@@ -12,6 +12,7 @@ class SyncConfluence {
         (err, data) => {
           if (err) {
             console.error(err);
+            process.exit(1);
           } else {
             if (data.results[0]) {
               resolve(data.results[0].id);
@@ -28,6 +29,7 @@ class SyncConfluence {
     return this.confluenceApi.getContentById(pageId, (err, data) => {
       if (err) {
         console.error(err);
+        process.exit(1);
       } else {
         cb(data.version.number);
       }
@@ -44,6 +46,7 @@ class SyncConfluence {
         (err, data) => {
           if (err) {
             console.error(err);
+            process.exit(1);
           } else {
             resolve(data.id);
           }
@@ -63,7 +66,10 @@ class SyncConfluence {
         (err, data) => {
           if (err) {
             console.error(err);
-          }
+            process.exit(1);
+          } else {
+            console.log("Uploaded content successfuly to page %s", data._links.base + data._links.webui);
+          }          
         },
         false,
         "editor2"
@@ -79,6 +85,7 @@ class SyncConfluence {
           (err, data) => {
             if (err) {
               console.error(err);
+              process.exit(1);
             } else {
               if (data.results[0]) {
                 resolve(data.results);
@@ -101,6 +108,7 @@ class SyncConfluence {
           (err, data) => {
             if (err) {
               console.error(err);
+              process.exit(1);
             } else {
               if (data) {
                 resolve(data);
@@ -122,6 +130,7 @@ class SyncConfluence {
           (err, data) => {
             if (err) {
               console.error(err);
+              process.exit(1);s
             } else {
               if (data.results[0]) {
                 resolve(data.results[0]);


### PR DESCRIPTION
Fixes: https://github.com/Bhacaz/docs-as-code-confluence/issues/7

This PR introduces two changes:

- Exit on any failure, so that the workflow shows as failed within GitHub actions.  Note this will fail on _any_ API failure.
- Output urls of pages that have been updated, or a message if no pages were found in the target directory