### PR TITLE
Remove accidental character added (typo).

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -18777,7 +18777,7 @@ class SyncConfluence {
           (err, data) => {
             if (err) {
               console.error(err);
-              process.exit(1);s
+              process.exit(1);
             } else {
               if (data.results[0]) {
                 resolve(data.results[0]);

--- a/utils/confluence.js
+++ b/utils/confluence.js
@@ -130,7 +130,7 @@ class SyncConfluence {
           (err, data) => {
             if (err) {
               console.error(err);
-              process.exit(1);s
+              process.exit(1);
             } else {
               if (data.results[0]) {
                 resolve(data.results[0]);


### PR DESCRIPTION
Hi @Bhacaz sorry there was an extra character accidentally added in the last PR https://github.com/Bhacaz/docs-as-code-confluence/pull/13

Creating a new PR to remove it.