### PR TITLE
Do not fail workflow when page is not found.

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -18658,8 +18658,7 @@ class SyncConfluence {
         title,
         (err, data) => {
           if (err) {
-            console.error(err);
-            process.exit(1);
+            resolve(undefined);
           } else {
             if (data.results[0]) {
               resolve(data.results[0].id);

--- a/utils/confluence.js
+++ b/utils/confluence.js
@@ -11,8 +11,7 @@ class SyncConfluence {
         title,
         (err, data) => {
           if (err) {
-            console.error(err);
-            process.exit(1);
+            resolve(undefined);
           } else {
             if (data.results[0]) {
               resolve(data.results[0].id);


### PR DESCRIPTION
Apologies again @Bhacaz, I have another fix from the https://github.com/Bhacaz/docs-as-code-confluence/pull/13

The search for page by title will return an 404 error if the page has not yet been created.  We don't want this to fail the workflow, as we then later create a page in this situation.

(We are using this github action in a slightly different way, so this didn't come up initially for us).